### PR TITLE
Make sure proof canonicalization is reproducible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/data-integrity Changelog
 
+## Unreleased
+
+### Fixed
+- Change json-ld context fallback in `canonizeProof` to the document's `@context`, adding the suite context only if necessary. This ensures that the canonicalized proof is identical in both issuance and verification.
+
 ## 1.4.0 - 2023-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # @digitalbazaar/data-integrity Changelog
 
-## Unreleased
+## 1.4.1 - 2023-08-dd
 
 ### Fixed
-- Change json-ld context fallback in `canonizeProof` to the document's `@context`, adding the suite context only if necessary. This ensures that the canonicalized proof is identical in both issuance and verification.
+- Change JSON-LD context fallback in `canonizeProof` to the document's
+  `@context`, adding the suite context only if necessary. This ensures that
+  the canonicalized proof is identical in both issuance and verification.
 
 ## 1.4.0 - 2023-05-21
 

--- a/lib/DataIntegrityProof.js
+++ b/lib/DataIntegrityProof.js
@@ -348,12 +348,13 @@ export class DataIntegrityProof extends LinkedDataProof {
     return verificationMethod;
   }
 
-  async canonizeProof(proof, {documentLoader}) {
+  async canonizeProof(proof, {documentLoader, document}) {
     // `proofValue` must not be included in the proof options
     proof = {
-      '@context': DATA_INTEGRITY_CONTEXT,
+      '@context': document['@context'],
       ...proof
     };
+    this.ensureSuiteContext({document: proof, addSuiteContext: true});
     delete proof.proofValue;
     return this.canonize(proof, {documentLoader, skipExpansion: false});
   }


### PR DESCRIPTION
Reminiscent of https://github.com/digitalbazaar/vc/issues/138, the use of the object composition syntax in `canonizeProof` results in existing `@context` property values taking precedence over the data-integrity context.
This means that this context is only added if no context is present at this point.
When using the `DataIntegrityProof` with `jsonld-signatures`, a `@context` property is likely not present when issuing a proof, but will be present during verification due to the [implementation of `ProofSet._getProofs`](https://github.com/digitalbazaar/jsonld-signatures/blob/567c8cf4479d2d8b6e65aa5e571c55d43573722b/lib/ProofSet.js#L225-L230).
As a consequence, signing will typically take place with the `@context` property value `https://w3id.org/security/data-integrity/v1` on the proof while during verification this value is either set to the document's context, or, if none exists, with the `jsonld-signatures` default `https://w3id.org/security/v2`.

While this difference may be overlooked by linked data based canonicalisation as long as definitions in the contexts used during signing and verification are equivalent, this __will break__ for jcs based proof schemes (see digitalbazaar/jsonld-signatures#176).
The proposed change will make sure that any existing `@context` values are overwritten with `https://w3id.org/security/data-integrity/v1` for the purpose of canonicalisation, resulting in identical input to the cryptosuite's `canonize()` function on proof issuance and verification.

In case forcing the proof context to the data integrity context is not desired, I'd recommend aligning with the behaviour of `jsonld-signatures` by setting the proof context to the document's context, and if not present, defaulting to the data integrity context instead.
