### PR TITLE
Remove `created` from proof by passing `date:null` into DataIntegrityProof constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @digitalbazaar/data-integrity Changelog
 
+## 2.1.0 - 2024-02-13
+
+### Added
+- Add option to pass `date: null` to the `DataIntegrityProof`
+  constructor, resulting in a proof without the `proof.created`
+  property.
+
 ## 2.0.0 - 2023-11-13
 
 ### Added

--- a/lib/DataIntegrityProof.js
+++ b/lib/DataIntegrityProof.js
@@ -59,6 +59,8 @@ export class DataIntegrityProof extends LinkedDataProof {
       if(isNaN(this.date)) {
         throw TypeError(`"date" "${date}" is not a valid date.`);
       }
+    } else if(date === null) {
+      this.date = null;
     }
 
     const vm = _processSignatureParams({signer, requiredAlgorithm});
@@ -164,19 +166,26 @@ export class DataIntegrityProof extends LinkedDataProof {
 
     // set default `now` date if not given in `proof` or `options`
     let date = this.date;
-    if(proof.created === undefined && date === undefined) {
-      date = new Date();
+    if(date === null) {
+      if(proof.created !== undefined) {
+        delete proof.created;
+      }
+    } else {
+      if(proof.created === undefined && date === undefined) {
+        date = new Date();
+      }
+
+      // ensure date is in string format
+      if(date && typeof date !== 'string') {
+        date = util.w3cDate(date);
+      }
+
+      // add API overrides
+      if(date) {
+        proof.created = date;
+      }
     }
 
-    // ensure date is in string format
-    if(date && typeof date !== 'string') {
-      date = util.w3cDate(date);
-    }
-
-    // add API overrides
-    if(date) {
-      proof.created = date;
-    }
     proof.verificationMethod = this.verificationMethod;
     proof.cryptosuite = this.cryptosuite;
 

--- a/lib/DataIntegrityProof.js
+++ b/lib/DataIntegrityProof.js
@@ -166,26 +166,19 @@ export class DataIntegrityProof extends LinkedDataProof {
 
     // set default `now` date if not given in `proof` or `options`
     let date = this.date;
-    if(date === null) {
-      if(proof.created !== undefined) {
-        delete proof.created;
-      }
-    } else {
-      if(proof.created === undefined && date === undefined) {
-        date = new Date();
-      }
-
-      // ensure date is in string format
-      if(date && typeof date !== 'string') {
-        date = util.w3cDate(date);
-      }
-
-      // add API overrides
-      if(date) {
-        proof.created = date;
-      }
+    if(proof.created === undefined && date === undefined) {
+      date = new Date();
     }
 
+    // ensure date is in string format
+    if(date && typeof date !== 'string') {
+      date = util.w3cDate(date);
+    }
+
+    // add API overrides
+    if(date) {
+      proof.created = date;
+    }
     proof.verificationMethod = this.verificationMethod;
     proof.cryptosuite = this.cryptosuite;
 

--- a/test/DataIntegrityProof.spec.js
+++ b/test/DataIntegrityProof.spec.js
@@ -195,6 +195,57 @@ describe('DataIntegrityProof', () => {
           'EEd5w8FATEigPA5788ByuwnCZrd');
     });
 
+    it('passing date:null should remove created from proof', async () => {
+      const unsignedCredential = {...credential};
+
+      const keyPair = await Ed25519Multikey.from({...ed25519MultikeyKeyPair});
+      const date = null;
+      const suite = new DataIntegrityProof({
+        signer: keyPair.signer(), date, cryptosuite: eddsa2022CryptoSuite
+      });
+
+      const signedCredential = await jsigs.sign(unsignedCredential, {
+        suite,
+        purpose: new AssertionProofPurpose(),
+        documentLoader
+      });
+      expect(signedCredential).to.have.property('proof');
+      expect(signedCredential.proof.created).to.not.exist;
+    });
+
+    it('created should exist with passed date', async () => {
+      const unsignedCredential = {...credential};
+
+      const keyPair = await Ed25519Multikey.from({...ed25519MultikeyKeyPair});
+      const date = '2022-09-06T21:29:24Z';
+      const suite = new DataIntegrityProof({
+        signer: keyPair.signer(), date, cryptosuite: eddsa2022CryptoSuite
+      });
+
+      const signedCredential = await jsigs.sign(unsignedCredential, {
+        suite,
+        purpose: new AssertionProofPurpose(),
+        documentLoader
+      });
+      expect(signedCredential.proof.created).to.exist;
+    });
+
+    it('created should exist with date not passed', async () => {
+      const unsignedCredential = {...credential};
+
+      const keyPair = await Ed25519Multikey.from({...ed25519MultikeyKeyPair});
+      const suite = new DataIntegrityProof({
+        signer: keyPair.signer(), cryptosuite: eddsa2022CryptoSuite
+      });
+
+      const signedCredential = await jsigs.sign(unsignedCredential, {
+        suite,
+        purpose: new AssertionProofPurpose(),
+        documentLoader
+      });
+      expect(signedCredential.proof.created).to.exist;
+    });
+
     it('should fail to sign with undefined term', async () => {
       const unsignedCredential = JSON.parse(JSON.stringify(credential));
       unsignedCredential.undefinedTerm = 'foo';


### PR DESCRIPTION
-passing `date: null` sets `this.date` to a dummy value which is then used to make sure `proof.created` is never added
-added tests for passing `date: null`, passing a real date, and passing no date